### PR TITLE
Migrate from svelte-kit package to @sveltejs/package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@sveltejs/adapter-static": "^1.0.0-next.42",
         "@sveltejs/kit": "next",
+        "@sveltejs/package": "^2.2.6",
         "@types/jest": "^29.0.0",
         "@typescript-eslint/eslint-plugin": "^5.36.2",
         "@typescript-eslint/parser": "^5.36.2",
@@ -31,12 +32,13 @@
       }
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
+      "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.0"
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -1036,29 +1038,52 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
-      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+      "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1162,6 +1187,56 @@
       },
       "peerDependencies": {
         "svelte": "^3.44.0"
+      }
+    },
+    "node_modules/@sveltejs/package": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@sveltejs/package/-/package-2.2.6.tgz",
+      "integrity": "sha512-rhKL/96M7LCvFI2xN94qsqHtEWr/ypcMGiii3s6dRW7ADt3tiDm8UfExjRR8v5jW3Femz0+VJ0TNevxI4Q9Quw==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "kleur": "^4.1.5",
+        "sade": "^1.8.1",
+        "semver": "^7.5.4",
+        "svelte2tsx": "~0.7.0"
+      },
+      "bin": {
+        "svelte-package": "svelte-package.js"
+      },
+      "engines": {
+        "node": "^16.14 || >=18"
+      },
+      "peerDependencies": {
+        "svelte": "^3.44.0 || ^4.0.0 || ^5.0.0-next.1"
+      }
+    },
+    "node_modules/@sveltejs/package/node_modules/svelte2tsx": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.7.0.tgz",
+      "integrity": "sha512-qAelcydnmuiDvD1HsrWi23RWx24RZTKRv6n4JaGC/pkoJfbLkJPQT2wa1qN0ZyfKTNLSyoj2FW9z62l/AUzUNA==",
+      "dev": true,
+      "dependencies": {
+        "dedent-js": "^1.0.1",
+        "pascal-case": "^3.1.1"
+      },
+      "peerDependencies": {
+        "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0",
+        "typescript": "^4.9.4 || ^5.0.0"
+      }
+    },
+    "node_modules/@sveltejs/package/node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
@@ -1514,9 +1589,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -2060,9 +2135,9 @@
       "dev": true
     },
     "node_modules/deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -4241,9 +4316,9 @@
       }
     },
     "node_modules/kleur": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
-      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -4459,10 +4534,16 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -4757,9 +4838,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "version": "8.4.33",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
+      "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
       "dev": true,
       "funding": [
         {
@@ -4769,10 +4850,14 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -5067,9 +5152,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -5822,12 +5907,13 @@
   },
   "dependencies": {
     "@ampproject/remapping": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
+      "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
       "dev": true,
       "requires": {
-        "@jridgewell/trace-mapping": "^0.3.0"
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
     "@babel/code-frame": {
@@ -6592,26 +6678,43 @@
         "chalk": "^4.0.0"
       }
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
     "@jridgewell/resolve-uri": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
-      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+      "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
       "dev": true,
       "requires": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "@nodelib/fs.scandir": {
@@ -6694,6 +6797,38 @@
         "@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
         "sade": "^1.7.4",
         "vite": "^2.9.0"
+      }
+    },
+    "@sveltejs/package": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@sveltejs/package/-/package-2.2.6.tgz",
+      "integrity": "sha512-rhKL/96M7LCvFI2xN94qsqHtEWr/ypcMGiii3s6dRW7ADt3tiDm8UfExjRR8v5jW3Femz0+VJ0TNevxI4Q9Quw==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^3.5.3",
+        "kleur": "^4.1.5",
+        "sade": "^1.8.1",
+        "semver": "^7.5.4",
+        "svelte2tsx": "~0.7.0"
+      },
+      "dependencies": {
+        "svelte2tsx": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.7.0.tgz",
+          "integrity": "sha512-qAelcydnmuiDvD1HsrWi23RWx24RZTKRv6n4JaGC/pkoJfbLkJPQT2wa1qN0ZyfKTNLSyoj2FW9z62l/AUzUNA==",
+          "dev": true,
+          "requires": {
+            "dedent-js": "^1.0.1",
+            "pascal-case": "^3.1.1"
+          }
+        },
+        "typescript": {
+          "version": "5.3.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+          "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+          "dev": true,
+          "peer": true
+        }
       }
     },
     "@sveltejs/vite-plugin-svelte": {
@@ -6944,9 +7079,9 @@
       }
     },
     "acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true
     },
     "acorn-jsx": {
@@ -7349,9 +7484,9 @@
       "dev": true
     },
     "deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true
     },
     "detect-indent": {
@@ -8890,9 +9025,9 @@
       }
     },
     "kleur": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
-      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "dev": true
     },
     "leven": {
@@ -9062,9 +9197,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "dev": true
     },
     "natural-compare": {
@@ -9282,12 +9417,12 @@
       }
     },
     "postcss": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "version": "8.4.33",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
+      "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
@@ -9486,9 +9621,9 @@
       }
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "dev": "svelte-kit dev",
     "build": "svelte-kit build",
-    "package": "node scripts/copy-css.js && svelte-kit package",
+    "package": "node scripts/copy-css.js && svelte-package -o package",
     "preview": "svelte-kit preview --port 3030",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@sveltejs/adapter-static": "^1.0.0-next.42",
     "@sveltejs/kit": "next",
+    "@sveltejs/package": "^2.0.0",
     "@types/jest": "^29.0.0",
     "@typescript-eslint/eslint-plugin": "^5.36.2",
     "@typescript-eslint/parser": "^5.36.2",
@@ -51,12 +52,175 @@
   },
   "type": "module",
   "exports": {
-    ".": "./index.js",
+    "./package.json": "./package.json",
+    ".": "./package/index.js",
     "./css": "./css/splide.min.css",
     "./css/core": "./css/splide-core.min.css",
-    "./css/*": "./css/themes/splide-*.min.css"
+    "./css/*": "./css/themes/splide-*.min.css",
+    "./components/Splide/Splide.svelte": {
+      "types": "./package/components/Splide/Splide.svelte.d.ts",
+      "svelte": "./package/components/Splide/Splide.svelte",
+      "default": "./package/components/Splide/Splide.svelte"
+    },
+    "./components/Splide/bind": {
+      "types": "./package/components/Splide/bind.d.ts",
+      "default": "./package/components/Splide/bind.js"
+    },
+    "./components/SplideSlide/SplideSlide.svelte": {
+      "types": "./package/components/SplideSlide/SplideSlide.svelte.d.ts",
+      "svelte": "./package/components/SplideSlide/SplideSlide.svelte",
+      "default": "./package/components/SplideSlide/SplideSlide.svelte"
+    },
+    "./components/SplideTrack/SplideTrack.svelte": {
+      "types": "./package/components/SplideTrack/SplideTrack.svelte.d.ts",
+      "svelte": "./package/components/SplideTrack/SplideTrack.svelte",
+      "default": "./package/components/SplideTrack/SplideTrack.svelte"
+    },
+    "./components": {
+      "types": "./package/components/index.d.ts",
+      "svelte": "./package/components/index.js",
+      "default": "./package/components/index.js"
+    },
+    "./css/splide-core.min.css": "./package/css/splide-core.min.css",
+    "./css/splide.min.css": "./package/css/splide.min.css",
+    "./css/themes/splide-default.min.css": "./package/css/themes/splide-default.min.css",
+    "./css/themes/splide-sea-green.min.css": "./package/css/themes/splide-sea-green.min.css",
+    "./css/themes/splide-skyblue.min.css": "./package/css/themes/splide-skyblue.min.css",
+    "./types/events": {
+      "types": "./package/types/events.d.ts",
+      "default": "./package/types/events.js"
+    },
+    "./types": {
+      "types": "./package/types/index.d.ts",
+      "svelte": "./package/types/index.js",
+      "default": "./package/types/index.js"
+    },
+    "./utils/classNames/classNames": {
+      "types": "./package/utils/classNames/classNames.d.ts",
+      "default": "./package/utils/classNames/classNames.js"
+    },
+    "./utils/forOwn/forOwn": {
+      "types": "./package/utils/forOwn/forOwn.d.ts",
+      "default": "./package/utils/forOwn/forOwn.js"
+    },
+    "./utils/forOwn/test/forOwn.test": {
+      "types": "./package/utils/forOwn/test/forOwn.test.d.ts",
+      "default": "./package/utils/forOwn/test/forOwn.test.js"
+    },
+    "./utils/getSlides/getSlides": {
+      "types": "./package/utils/getSlides/getSlides.d.ts",
+      "default": "./package/utils/getSlides/getSlides.js"
+    },
+    "./utils": {
+      "types": "./package/utils/index.d.ts",
+      "svelte": "./package/utils/index.js",
+      "default": "./package/utils/index.js"
+    },
+    "./utils/isEqualDeep/isEqualDeep": {
+      "types": "./package/utils/isEqualDeep/isEqualDeep.d.ts",
+      "default": "./package/utils/isEqualDeep/isEqualDeep.js"
+    },
+    "./utils/isEqualDeep/test/isEqualDeep.test": {
+      "types": "./package/utils/isEqualDeep/test/isEqualDeep.test.d.ts",
+      "default": "./package/utils/isEqualDeep/test/isEqualDeep.test.js"
+    },
+    "./utils/isEqualShallow/isEqualShallow": {
+      "types": "./package/utils/isEqualShallow/isEqualShallow.d.ts",
+      "default": "./package/utils/isEqualShallow/isEqualShallow.js"
+    },
+    "./utils/isEqualShallow/test/isEqualShallow.test": {
+      "types": "./package/utils/isEqualShallow/test/isEqualShallow.test.d.ts",
+      "default": "./package/utils/isEqualShallow/test/isEqualShallow.test.js"
+    },
+    "./utils/isObject/isObject": {
+      "types": "./package/utils/isObject/isObject.d.ts",
+      "default": "./package/utils/isObject/isObject.js"
+    },
+    "./utils/isObject/test/isObject.test": {
+      "types": "./package/utils/isObject/test/isObject.test.d.ts",
+      "default": "./package/utils/isObject/test/isObject.test.js"
+    },
+    "./utils/merge/merge.test": {
+      "types": "./package/utils/merge/merge.test.d.ts",
+      "default": "./package/utils/merge/merge.test.js"
+    },
+    "./utils/merge/merge": {
+      "types": "./package/utils/merge/merge.d.ts",
+      "default": "./package/utils/merge/merge.js"
+    }
   },
   "dependencies": {
     "@splidejs/splide": "^4.1.3"
+  },
+  "files": [
+    "package"
+  ],
+  "svelte": "./package/index.js",
+  "typesVersions": {
+    ">4.0": {
+      "components/Splide/Splide.svelte": [
+        "./package/components/Splide/Splide.svelte.d.ts"
+      ],
+      "components/Splide/bind": [
+        "./package/components/Splide/bind.d.ts"
+      ],
+      "components/SplideSlide/SplideSlide.svelte": [
+        "./package/components/SplideSlide/SplideSlide.svelte.d.ts"
+      ],
+      "components/SplideTrack/SplideTrack.svelte": [
+        "./package/components/SplideTrack/SplideTrack.svelte.d.ts"
+      ],
+      "components": [
+        "./package/components/index.d.ts"
+      ],
+      "index.d.ts": [
+        "./package/index.d.ts"
+      ],
+      "types/events": [
+        "./package/types/events.d.ts"
+      ],
+      "types": [
+        "./package/types/index.d.ts"
+      ],
+      "utils/classNames/classNames": [
+        "./package/utils/classNames/classNames.d.ts"
+      ],
+      "utils/forOwn/forOwn": [
+        "./package/utils/forOwn/forOwn.d.ts"
+      ],
+      "utils/forOwn/test/forOwn.test": [
+        "./package/utils/forOwn/test/forOwn.test.d.ts"
+      ],
+      "utils/getSlides/getSlides": [
+        "./package/utils/getSlides/getSlides.d.ts"
+      ],
+      "utils": [
+        "./package/utils/index.d.ts"
+      ],
+      "utils/isEqualDeep/isEqualDeep": [
+        "./package/utils/isEqualDeep/isEqualDeep.d.ts"
+      ],
+      "utils/isEqualDeep/test/isEqualDeep.test": [
+        "./package/utils/isEqualDeep/test/isEqualDeep.test.d.ts"
+      ],
+      "utils/isEqualShallow/isEqualShallow": [
+        "./package/utils/isEqualShallow/isEqualShallow.d.ts"
+      ],
+      "utils/isEqualShallow/test/isEqualShallow.test": [
+        "./package/utils/isEqualShallow/test/isEqualShallow.test.d.ts"
+      ],
+      "utils/isObject/isObject": [
+        "./package/utils/isObject/isObject.d.ts"
+      ],
+      "utils/isObject/test/isObject.test": [
+        "./package/utils/isObject/test/isObject.test.d.ts"
+      ],
+      "utils/merge/merge.test": [
+        "./package/utils/merge/merge.test.d.ts"
+      ],
+      "utils/merge/merge": [
+        "./package/utils/merge/merge.d.ts"
+      ]
+    }
   }
 }


### PR DESCRIPTION
<!--
  Please make sure to add a new issue before you send PR!
-->

## Related Issues

https://github.com/Splidejs/svelte-splide/issues/12

## Description

See https://github.com/sveltejs/kit/pull/8922 for the information about required updates.

What I did in the PR:
1. `npm i -D @sveltejs/package`
2. `npx svelte-migrate package`

Not sure, but maybe additional changes can be made to this PR.. I have never worked on publishing svelte packages and actually any types of packages. What I think is that maybe `.npmignore` can be added, which would list files which are not needed for a package to work, at least `.github` folder? What do you think?